### PR TITLE
Framework stubs 2

### DIFF
--- a/misc/module/table/table.game.php
+++ b/misc/module/table/table.game.php
@@ -1,40 +1,42 @@
 <?php
+define('APP_GAMEMODULE_PATH', '');
 
 /**
- * Collection of stub classes for testing
+ * Collection of stub classes for testing and stubs
  */
+class APP_Object {
 
-class APP_Object {    
     function dump($v, $value) {
         echo "$v=";
         var_dump($value);
     }
-    
+
     function info($value) {
         echo "$value\n";
     }
-    
+
     function trace($value) {
         echo "$value\n";
     }
-    
+
     function debug($value) {
         echo "$value\n";
     }
-    
+
     function watch($value) {
         echo "$value\n";
     }
-    
+
     function warn($value) {
         echo "$value\n";
     }
-    
+
     function error($msg) {
         echo "$msg\n";
     }
 }
-class APP_DbObject extends APP_Object{
+
+class APP_DbObject extends APP_Object {
     public $query;
 
     function DbQuery($str) {
@@ -42,8 +44,24 @@ class APP_DbObject extends APP_Object{
         echo "dbquery: $str\n";
     }
 
+    function getUniqueValueFromDB($sql) {
+        return 0;
+    }
+
     function getCollectionFromDB($query, $single = false) {
         echo "dbquery coll: $query\n";
+        return array ();
+    }
+
+    function getNonEmptyCollectionFromDB($sql) {
+        return array ();
+    }
+
+    function getObjectFromDB($sql) {
+        return array ();
+    }
+
+    function getNonEmptyObjectFromDB($sql) {
         return array ();
     }
 
@@ -52,16 +70,23 @@ class APP_DbObject extends APP_Object{
         return array ();
     }
 
-    function getUniqueValueFromDB() {
-        return 0;
+    function getDoubleKeyCollectionFromDB($sql, $bSingleValue = false) {
+        return array ();
     }
-    
 
+    function DbGetLastId() {
+    }
+
+    function DbAffectedRow() {
+    }
+
+    function escapeStringForDB($string) {
+    }
 }
 
 class APP_GameClass extends APP_DbObject {
+
     public function __construct() {
-        
     }
 }
 
@@ -72,6 +97,33 @@ class GameState {
 
     function state() {
         return array ();
+    }
+
+    function changeActivePlayer($player_id) {
+    }
+
+    function setAllPlayersMultiactive() {
+    }
+
+    function setAllPlayersNonMultiactive($next_state) {
+    }
+
+    function setPlayersMultiactive($players, $next_state, $bExclusive = false) {
+    }
+
+    function setPlayerNonMultiactive($player_id, $next_state) {
+    }
+
+    function getActivePlayerList() {
+    }
+
+    function updateMultiactiveOrNextState($next_state_if_none) {
+    }
+
+    function nextState($transition) {
+    }
+
+    function checkPossibleAction($action) {
     }
 }
 
@@ -84,14 +136,14 @@ class BgaVisibleSystemException extends Exception {
 class feException extends Exception {
 }
 
-
 class Table extends APP_GameClass {
+    public $gamestate;
+    public $players;
 
     public function __construct() {
         parent::__construct();
         $this->gamestate = new GameState();
-        $this->players = array (
-                1 => array ('player_name' => $this->getActivePlayerName(),'player_color' => 'ff0000' ),
+        $this->players = array (1 => array ('player_name' => $this->getActivePlayerName(),'player_color' => 'ff0000' ),
                 2 => array ('player_name' => 'player2','player_color' => '0000ff' ) );
     }
 
@@ -103,7 +155,85 @@ class Table extends APP_GameClass {
         return "player1";
     }
 
+    function loadPlayersBasicInfos() {
+        $default_colors = array ("ff0000","008000","0000ff","ffa500","4c1b5b" );
+        $values = array ();
+        $id = 1;
+        foreach ( $default_colors as $color ) {
+            $values [$id] = array ('player_id' => $id,'player_color' => $color,'player_name' => "player$id" );
+            $id++;
+        }
+        return $values;
+    }
+
+    function getCurrentPlayerId() {
+        return 0;
+    }
+
+    function getCurrentPlayerName() {
+        return '';
+    }
+
+    function getCurrentPlayerColor() {
+        return '';
+    }
+
+    function isCurrentPlayerZombie() {
+        return false;
+    }
+
+    function getActivePlayerColor() {
+        return '';
+    }
+
     function initGameStateLabels($labels) {
+    }
+
+    function setGameStateInitialValue($value_label, $value_value) {
+    }
+
+    function getGameStateValue($value_label) {
+        return 0;
+    }
+
+    function setGameStateValue($value_label, $value_value) {
+    }
+
+    function incGameStateValue($value_label, $increment) {
+        return 0;
+    }
+
+    function activeNextPlayer() {
+    }
+
+    function activePrevPlayer() {
+    }
+
+    function checkAction($actionName, $bThrowException = true) {
+    }
+
+    function getNextPlayerTable() {
+        return 0;
+    }
+
+    function getPrevPlayerTable() {
+        return 0;
+    }
+
+    function getPlayerAfter($player_id) {
+        return 0;
+    }
+
+    function getPlayerBefore($player_id) {
+        return 0;
+    }
+
+    function createNextPlayerTable($players, $bLoop = true) {
+        return array ();
+    }
+
+    function createPrevPlayerTable($players, $bLoop = true) {
+        return array ();
     }
 
     function notifyAllPlayers($type, $message, $args) {
@@ -117,44 +247,55 @@ class Table extends APP_GameClass {
         echo "\n";
     }
 
-
-
-    function getGameStateValue($var) {
-        return 0;
-    }
-
-    function setGameStateValue($value_label, $value_value) {
-    }
-
-    function _($s) {
-        return $s;
-    }
-
-    function getPlayersNumber() {
-        return 2;
-    }
-
-
-
-    function setStat( $value, $name, $player_id = null, $bDoNotLoop=false ) {
-     echo "stat: $name=$value\n";
+    function notifyPlayer($player_id, $notification_type, $notification_log, $notification_args) {
     }
 
     function getStatTypes() {
         return array ();
     }
 
-    function loadPlayersBasicInfos() {
-        $default_colors = array ("ff0000","008000","0000ff","ffa500","4c1b5b" );
-        $values = array ();
-        $id = 1;
-        foreach ( $default_colors as $color ) {
-            $values [$id] = array ('player_id' => $id,'player_color' => $color,'player_name' => "player$id" );
-            $id ++;
-        }
-        return $values;
+    function initStat($table_or_player, $name, $value, $player_id = null) {
     }
 
+    function setStat($value, $name, $player_id = null, $bDoNotLoop = false) {
+        echo "stat: $name=$value\n";
+    }
+
+    function incStat($delta, $name, $player_id = null) {
+    }
+
+    function getStat($name, $player_id = null) {
+        return 0;
+    }
+
+    function _($s) {
+        return $s;
+    }
+
+    function reattributeColorsBasedOnPreferences($players, $colors) {
+    }
+
+    function reloadPlayersBasicInfos() {
+    }
+
+    function getNew($deck_definition) {
+    }
+
+    function giveExtraTime($player_id) {
+    }
+
+    function getStandardGameResultObject() {
+        return array ();
+    }
+
+    function applyDbChangeToAllDB($sql) {
+    }
+
+    // DEPRECATED
+    function applyDbUpgradeToAllDB($sql) {
+    }
+
+    // DEPRECATED
     function getGameinfos() {
         unset($gameinfos);
         require ('gameinfos.inc.php');
@@ -185,11 +326,13 @@ class GUser {
 }
 
 class game_view {
-    
 }
 
 class APP_GameAction {
-    
+}
+
+function totranslate($text) {
+    return $text;
 }
 
 function clienttranslate($x) {
@@ -200,6 +343,14 @@ function mysql_fetch_assoc($res) {
     return array ();
 }
 
-function totranslate($text) {
-    return $text;
+function bga_rand($min, $max) {
+    return 0;
+}
+
+function getKeysWithMaximum($array) {
+    return array ();
+}
+
+function getKeyWithMaximum($array) {
+    return '';
 }

--- a/misc/module/table/table.game.php
+++ b/misc/module/table/table.game.php
@@ -383,7 +383,7 @@ function bga_rand($min, $max) {
     return 0;
 }
 
-function getKeysWithMaximum($array) {
+function getKeysWithMaximum( $array, $bWithMaximum=true ) {
     return array ();
 }
 

--- a/misc/module/table/table.game.php
+++ b/misc/module/table/table.game.php
@@ -5,32 +5,32 @@ define('APP_GAMEMODULE_PATH', '');
  * Collection of stub classes for testing and stubs
  */
 class APP_Object {
-
+    
     function dump($v, $value) {
         echo "$v=";
         var_dump($value);
     }
-
+    
     function info($value) {
         echo "$value\n";
     }
-
+    
     function trace($value) {
         echo "$value\n";
     }
-
+    
     function debug($value) {
         echo "$value\n";
     }
-
+    
     function watch($value) {
         echo "$value\n";
     }
-
+    
     function warn($value) {
         echo "$value\n";
     }
-
+    
     function error($msg) {
         echo "$msg\n";
     }
@@ -38,91 +38,91 @@ class APP_Object {
 
 class APP_DbObject extends APP_Object {
     public $query;
-
+    
     function DbQuery($str) {
         $this->query = $str;
         echo "dbquery: $str\n";
     }
-
+    
     function getUniqueValueFromDB($sql) {
         return 0;
     }
-
+    
     function getCollectionFromDB($query, $single = false) {
         echo "dbquery coll: $query\n";
         return array ();
     }
-
+    
     function getNonEmptyCollectionFromDB($sql) {
         return array ();
     }
-
+    
     function getObjectFromDB($sql) {
         return array ();
     }
-
+    
     function getNonEmptyObjectFromDB($sql) {
         return array ();
     }
-
+    
     function getObjectListFromDB($query, $single = false) {
         echo "dbquery list: $query\n";
         return array ();
     }
-
+    
     function getDoubleKeyCollectionFromDB($sql, $bSingleValue = false) {
         return array ();
     }
-
+    
     function DbGetLastId() {
     }
-
+    
     function DbAffectedRow() {
     }
-
+    
     function escapeStringForDB($string) {
     }
 }
 
 class APP_GameClass extends APP_DbObject {
-
+    
     public function __construct() {
     }
 }
 
 class GameState {
-
+    
     function GameState() {
     }
-
+    
     function state() {
         return array ();
     }
-
+    
     function changeActivePlayer($player_id) {
     }
-
+    
     function setAllPlayersMultiactive() {
     }
-
+    
     function setAllPlayersNonMultiactive($next_state) {
     }
-
+    
     function setPlayersMultiactive($players, $next_state, $bExclusive = false) {
     }
-
+    
     function setPlayerNonMultiactive($player_id, $next_state) {
     }
-
+    
     function getActivePlayerList() {
     }
-
+    
     function updateMultiactiveOrNextState($next_state_if_none) {
     }
-
+    
     function nextState($transition) {
     }
-
+    
     function checkPossibleAction($action) {
     }
 }
@@ -136,25 +136,37 @@ class BgaVisibleSystemException extends Exception {
 class feException extends Exception {
 }
 
-class Table extends APP_GameClass {
-    public $gamestate;
-    public $players;
-
+abstract class Table extends APP_GameClass {
+    var $players = array();
+    var $gamename;
+    var $gamestate = null;
+    
     public function __construct() {
         parent::__construct();
         $this->gamestate = new GameState();
         $this->players = array (1 => array ('player_name' => $this->getActivePlayerName(),'player_color' => 'ff0000' ),
                 2 => array ('player_name' => 'player2','player_color' => '0000ff' ) );
     }
-
+    
+    /** Report gamename for translation function */
+    abstract protected function getGameName( );
+    
     function getActivePlayerId() {
         return 1;
     }
-
+    
     function getActivePlayerName() {
         return "player1";
     }
-
+    
+    function getTableOptions() {
+        return [ ];
+    }
+    
+    function getTablePreferences() {
+        return [ ];
+    }
+    
     function loadPlayersBasicInfos() {
         $default_colors = array ("ff0000","008000","0000ff","ffa500","4c1b5b" );
         $values = array ();
@@ -165,77 +177,84 @@ class Table extends APP_GameClass {
         }
         return $values;
     }
-
-    function getCurrentPlayerId() {
+    
+    protected function getCurrentPlayerId() {
         return 0;
     }
-
-    function getCurrentPlayerName() {
+    
+    protected function getCurrentPlayerName() {
         return '';
     }
-
-    function getCurrentPlayerColor() {
+    
+    protected function getCurrentPlayerColor() {
         return '';
     }
-
+    
     function isCurrentPlayerZombie() {
         return false;
     }
-
-    function getActivePlayerColor() {
-        return '';
-    }
-
+    
+    
+    /**
+     * Setup correspondance "labels to id"
+     * @param [] $labels - map string -> int (label of state variable -> numeric id in the database)
+     */
     function initGameStateLabels($labels) {
     }
-
+    
     function setGameStateInitialValue($value_label, $value_value) {
     }
-
+    
     function getGameStateValue($value_label) {
         return 0;
     }
-
+    
     function setGameStateValue($value_label, $value_value) {
     }
-
+    
     function incGameStateValue($value_label, $increment) {
         return 0;
     }
-
-    function activeNextPlayer() {
+    
+    protected function activeNextPlayer() {
     }
-
-    function activePrevPlayer() {
+    
+    protected function activePrevPlayer() {
     }
-
+    
+    /**
+     * Check if action is valid regarding current game state (exception if fails)
+     if "bThrowException" is set to "false", the function return false in case of failure instead of throwing and exception
+     * @param string $actionName
+     * @param boolean $bThrowException
+     */
     function checkAction($actionName, $bThrowException = true) {
     }
-
+    
     function getNextPlayerTable() {
         return 0;
     }
-
+    
     function getPrevPlayerTable() {
         return 0;
     }
-
+    
     function getPlayerAfter($player_id) {
         return 0;
     }
-
+    
     function getPlayerBefore($player_id) {
         return 0;
     }
-
+    
     function createNextPlayerTable($players, $bLoop = true) {
         return array ();
     }
-
+    
     function createPrevPlayerTable($players, $bLoop = true) {
         return array ();
     }
-
+    
     function notifyAllPlayers($type, $message, $args) {
         $args2 = array ();
         foreach ( $args as $key => $val ) {
@@ -246,56 +265,66 @@ class Table extends APP_GameClass {
         //. strtr($message,                $args2)
         echo "\n";
     }
-
+    
     function notifyPlayer($player_id, $notification_type, $notification_log, $notification_args) {
     }
-
+    
     function getStatTypes() {
         return array ();
     }
-
+    
     function initStat($table_or_player, $name, $value, $player_id = null) {
     }
-
+    
     function setStat($value, $name, $player_id = null, $bDoNotLoop = false) {
         echo "stat: $name=$value\n";
     }
-
+    
     function incStat($delta, $name, $player_id = null) {
     }
-
+    
     function getStat($name, $player_id = null) {
         return 0;
     }
-
+    
     function _($s) {
         return $s;
     }
-
+    
+    function getPlayersNumber() {
+        return 2;
+    }
+    
     function reattributeColorsBasedOnPreferences($players, $colors) {
     }
-
+    
     function reloadPlayersBasicInfos() {
     }
-
+    
     function getNew($deck_definition) {
     }
-
-    function giveExtraTime($player_id) {
+    
+    // Give standard extra time to this player
+    // (standard extra time is a game option)
+    function giveExtraTime( $player_id, $specific_time=null ) {
+        
     }
-
+    
     function getStandardGameResultObject() {
         return array ();
     }
-
+    
     function applyDbChangeToAllDB($sql) {
     }
-
-    // DEPRECATED
+    
+    /**
+     *
+     * @deprecated
+     */
     function applyDbUpgradeToAllDB($sql) {
     }
-
-    // DEPRECATED
+    
+    
     function getGameinfos() {
         unset($gameinfos);
         require ('gameinfos.inc.php');
@@ -304,22 +333,29 @@ class Table extends APP_GameClass {
         }
         throw new feException("gameinfos.inp.php suppose to define \$gameinfos variable");
     }
+    
+    /* Method to override to set up each game */
+    abstract protected function setupNewGame( $players, $options = array() );
+    
+    public function stMakeEveryoneActive() {
+        $this->gamestate->setAllPlayersMultiactive();
+    }
 }
 
 class Page {
     public $blocks = array ();
-
+    
     public function begin_block($template, $block) {
         $this->blocks [$block] = array ();
     }
-
+    
     public function insert_block($block, $args) {
         $this->blocks [$block] [] = $args;
     }
 }
 
 class GUser {
-
+    
     public function get_id() {
         return 1;
     }


### PR DESCRIPTION
galehar:
Add more stubs methodss to table.game.php

    The goal is to use it to make the IDE happy. That's why I've also
declared
    the methods as static as they are usually called with self:: form.

    I didn't kept the body of the methods as I had no use for them,
although
    maybe they should be readded if they are useful for testing.

    I did kept (and added) the return statements so that the IDE is
aware of
    the type of data returned by the methods.

    I also changed the name of some of the parameters to make them
consistent
    with the BGA Studio documentation.

VictoriaLa: restore methods that do some stubbing for tests, added some commends