### PR TITLE
Add bIndependantMultiactiveTable

### DIFF
--- a/misc/module/table/table.game.php
+++ b/misc/module/table/table.game.php
@@ -4,6 +4,10 @@ if (!defined('APP_GAMEMODULE_PATH')) {
     define('APP_GAMEMODULE_PATH', '');
 }
 
+if (!defined('APP_BASE_PATH')) {
+    define('APP_BASE_PATH', '');
+}
+
 /**
  * Collection of stub classes for testing and stubs
  */


### PR DESCRIPTION
As documented on https://boardgamearena.com/doc/Troubleshooting, the variable bIndependantMultiactiveTable can be set to help resolve deadlocks.